### PR TITLE
Fix:Resolve duplicate method and JSON parsing errors in WeatherService

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,6 +68,8 @@ dependencies {
     implementation("org.apache.httpcomponents.core5:httpcore5-h2:5.2.1")
 
     implementation("io.arrow-kt:arrow-core:1.2.0")
+    implementation ("org.springframework.retry:spring-retry:2.0.6")
+    implementation ("org.springframework:spring-aspects:6.1.12")
 }
 
 kotlin {

--- a/src/main/kotlin/com/kweather/domain/airstagnation/dto/AirStagnationIndexBody.kt
+++ b/src/main/kotlin/com/kweather/domain/airstagnation/dto/AirStagnationIndexBody.kt
@@ -1,6 +1,11 @@
 package com.kweather.domain.airstagnation.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class AirStagnationIndexBody(
+    @JsonDeserialize(using = SingleObjectToListDeserializer::class)
     val items: List<AirStagnationIndexItem>? = null,
     val pageNo: Int? = null,
     val numOfRows: Int? = null,

--- a/src/main/kotlin/com/kweather/domain/airstagnation/dto/SingleObjectToListDeserializer.kt
+++ b/src/main/kotlin/com/kweather/domain/airstagnation/dto/SingleObjectToListDeserializer.kt
@@ -1,0 +1,17 @@
+package com.kweather.domain.airstagnation.dto
+
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonNode
+
+class SingleObjectToListDeserializer : StdDeserializer<List<AirStagnationIndexItem>>(List::class.java) {
+    override fun deserialize(p: com.fasterxml.jackson.core.JsonParser, ctxt: DeserializationContext): List<AirStagnationIndexItem> {
+        val node: JsonNode = p.codec.readTree(p)
+        val mapper = p.codec as com.fasterxml.jackson.databind.ObjectMapper
+        return if (node.isObject) {
+            listOf(mapper.treeToValue(node.get("item"), AirStagnationIndexItem::class.java))
+        } else {
+            mapper.treeToValue(node.get("item"), List::class.java) as List<AirStagnationIndexItem>
+        }
+    }
+}

--- a/src/main/kotlin/com/kweather/domain/senta/dto/SenTaIndexBody.kt
+++ b/src/main/kotlin/com/kweather/domain/senta/dto/SenTaIndexBody.kt
@@ -1,5 +1,8 @@
 package com.kweather.domain.senta.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class SenTaIndexBody(
     val items: List<SenTaIndexItem>? = null,
     val pageNo: Int? = null,

--- a/src/main/kotlin/com/kweather/domain/senta/dto/SingleObjectToListDeserializer.kt
+++ b/src/main/kotlin/com/kweather/domain/senta/dto/SingleObjectToListDeserializer.kt
@@ -1,0 +1,18 @@
+package com.kweather.domain.senta.dto
+
+
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonNode
+
+class SingleObjectToListDeserializer : StdDeserializer<List<SenTaIndexItem>>(List::class.java) {
+    override fun deserialize(p: com.fasterxml.jackson.core.JsonParser, ctxt: DeserializationContext): List<SenTaIndexItem> {
+        val node: JsonNode = p.codec.readTree(p)
+        val mapper = p.codec as com.fasterxml.jackson.databind.ObjectMapper
+        return if (node.isObject) {
+            listOf(mapper.treeToValue(node.get("item"), SenTaIndexItem::class.java))
+        } else {
+            mapper.treeToValue(node.get("item"), List::class.java) as List<SenTaIndexItem>
+        }
+    }
+}

--- a/src/main/kotlin/com/kweather/domain/uvi/dto/UVIndexBody.kt
+++ b/src/main/kotlin/com/kweather/domain/uvi/dto/UVIndexBody.kt
@@ -1,5 +1,8 @@
 package com.kweather.domain.uvi.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class UVIndexBody(
     val items: List<UVIndexItem>? = null,
     val pageNo: Int? = null,

--- a/src/main/kotlin/com/kweather/domain/uvi/dto/UVIndexItem.kt
+++ b/src/main/kotlin/com/kweather/domain/uvi/dto/UVIndexItem.kt
@@ -1,6 +1,5 @@
 package com.kweather.domain.uvi.dto
 
-
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/src/main/kotlin/com/kweather/domain/uvi/dto/UVSingleObjectToListDeserializer.kt
+++ b/src/main/kotlin/com/kweather/domain/uvi/dto/UVSingleObjectToListDeserializer.kt
@@ -1,0 +1,17 @@
+package com.kweather.domain.uvi.dto
+
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonNode
+
+class UVSingleObjectToListDeserializer : StdDeserializer<List<UVIndexItem>>(List::class.java) {
+    override fun deserialize(p: com.fasterxml.jackson.core.JsonParser, ctxt: DeserializationContext): List<UVIndexItem> {
+        val node: JsonNode = p.codec.readTree(p)
+        val mapper = p.codec as com.fasterxml.jackson.databind.ObjectMapper
+        return if (node.isObject) {
+            listOf(mapper.treeToValue(node.get("item"), UVIndexItem::class.java))
+        } else {
+            mapper.treeToValue(node.get("item"), List::class.java) as List<UVIndexItem>
+        }
+    }
+}

--- a/src/main/kotlin/com/kweather/global/common/util/DateTimeUtils.kt
+++ b/src/main/kotlin/com/kweather/global/common/util/DateTimeUtils.kt
@@ -8,6 +8,10 @@ import java.util.*
 
 object DateTimeUtils {
 
+    fun getCurrentApiTime(): String {
+        return LocalDateTime.now(ZoneId.of("Asia/Seoul")).format(DateTimeFormatter.ofPattern("yyyyMMddHH"))
+    }
+
     fun getCurrentDateTimeFormatted(): Pair<String, String> {
         val now = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
         val year = now.year


### PR DESCRIPTION
- Removed duplicate parseUVIndexItem method to resolve overload ambiguity
- Added custom deserializers for SenTaIndexBody and UVIndexBody to handle single-object items
- Fixed ApiResult type checking and getOrElse usage for better type safety
- Ensured consistent time format (yyyyMMddHH) in AirStagnationIndex API calls
- Added debug logging for null/empty fields in parsing methods b685c7