### PR TITLE
fix: Resolve type mismatch in WeatherService parseResponse methods

### DIFF
--- a/src/main/kotlin/com/kweather/domain/realtime/dto/RealTimeDustItem.kt
+++ b/src/main/kotlin/com/kweather/domain/realtime/dto/RealTimeDustItem.kt
@@ -2,18 +2,17 @@ package com.kweather.domain.realtime.dto
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 
-
 @JsonIgnoreProperties(ignoreUnknown = true)
 data class RealTimeDustItem(
-    val sidoName: String? = null,          // 시도 이름 (예: 서울)
-    val stationName: String? = null,       // 측정소 이름 (예: 중구)
-    val pm10Value: String? = null,         // 미세먼지(PM10) 농도 (μg/m³)
-    val pm25Value: String? = null,         // 초미세먼지(PM2.5) 농도 (μg/m³)
-    val pm10Grade: String? = null,         // 미세먼지(PM10) 등급 (1: 좋음, 2: 보통, 3: 나쁨, 4: 매우나쁨)
-    val pm25Grade: String? = null,         // 초미세먼지(PM2.5) 등급
-    val dataTime: String? = null,           // 측정 시간 (예: 2020-11-14 14시)
-    val so2Grade: String? = null,         // SO2 등급
-    val coValue: String? = null,          // CO 농도
-    val khaiValue: String? = null,        // 종합 대기질 지수
-    val o3Grade: String? = null,          // 오존 등급
+    val sidoName: String? = null,
+    val stationName: String? = null,
+    val pm10Value: String? = null,
+    val pm25Value: String? = null,
+    val pm10Grade: String? = null,
+    val pm25Grade: String? = null,
+    val dataTime: String? = null,
+    val so2Grade: String? = null,
+    val coValue: String? = null,
+    val khaiValue: String? = null,
+    val o3Grade: String? = null
 )

--- a/src/main/kotlin/com/kweather/domain/senta/dto/SenTaIndexItem.kt
+++ b/src/main/kotlin/com/kweather/domain/senta/dto/SenTaIndexItem.kt
@@ -34,5 +34,6 @@ data class SenTaIndexItem(
     val h28: String?,
     val h29: String?,
     val h30: String?,
-    val h31: String?
+    val h31: String?,
+    val h32: String?
 )

--- a/src/main/kotlin/com/kweather/domain/senta/dto/SenTaIndexItems.kt
+++ b/src/main/kotlin/com/kweather/domain/senta/dto/SenTaIndexItems.kt
@@ -1,7 +1,9 @@
 package com.kweather.domain.senta.dto
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class SenTaIndexItems(
     @JsonProperty("item")
     val item: List<SenTaIndexItem>? = null

--- a/src/main/kotlin/com/kweather/domain/weather/model/Items.kt
+++ b/src/main/kotlin/com/kweather/domain/weather/model/Items.kt
@@ -1,8 +1,12 @@
 package com.kweather.domain.weather.model
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 data class Items<T>(
     @JsonProperty("item")
+    @JsonDeserialize(using = ItemsDeserializer::class)
     val item: List<T>? = null
 )

--- a/src/main/kotlin/com/kweather/domain/weather/model/ItemsDeserializer.kt
+++ b/src/main/kotlin/com/kweather/domain/weather/model/ItemsDeserializer.kt
@@ -1,0 +1,24 @@
+package com.kweather.domain.weather.model
+
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonNode
+
+class ItemsDeserializer<T : Any>(vc: Class<*>? = null) : StdDeserializer<List<T>>(vc) {
+    override fun deserialize(p: com.fasterxml.jackson.core.JsonParser, ctxt: DeserializationContext): List<T> {
+        val node: JsonNode = p.codec.readTree(p)
+        return when {
+            node.isArray -> {
+                val type = ctxt.typeFactory.constructType(valueType)
+                node.elements().asSequence().mapNotNull {
+                    p.codec.treeToValue(it, type.rawClass) as? T
+                }.toList()
+            }
+            node.isObject -> {
+                val type = ctxt.typeFactory.constructType(valueType)
+                listOfNotNull(p.codec.treeToValue(node, type.rawClass) as? T)
+            }
+            else -> emptyList()
+        }
+    }
+}


### PR DESCRIPTION
- Fixed Jackson readValue type inference issues in WeatherApiClient and other ApiClients
- Updated parseResponse to use explicit Class<T> for correct Either<String, T> return types
- Ensured consistent JSON parsing across Weather, Dust, UVIndex, SenTaIndex, and AirStagnationIndex APIs